### PR TITLE
Set astro cookies in LambdaEdge function response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ yarn-debug.log*
 yarn-error.log*
 package.tgz
 apps/www/src/pages/docs/packages/*
+
+.idea

--- a/packages/adapter/src/lambda/__tests__/helpers.test.ts
+++ b/packages/adapter/src/lambda/__tests__/helpers.test.ts
@@ -2,7 +2,7 @@ import type { App } from "astro/app";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { faker } from "@faker-js/faker";
 
-import { createLambdaFunctionResponse } from "../helpers.js";
+import { createLambdaFunctionResponse, createLambdaEdgeFunctionResponse } from "../helpers.js";
 
 const knownBinaryMediaTypes = new Set(["image/png", "image/jpeg"]);
 
@@ -42,6 +42,65 @@ describe("helpers", () => {
 				headers,
 				isBase64Encoded: false,
 				statusCode: 200,
+			});
+		});
+	});
+
+	describe("createLambdaEdgeFunctionResponse", () => {
+		let response: Response,
+			app: App,
+			fnResponse: Awaited<ReturnType<typeof createLambdaEdgeFunctionResponse>>,
+			body: string,
+			headers: Record<string, string>;
+
+		beforeEach(async () => {
+			body = faker.datatype.string();
+			headers = {
+				"content-type": "text/plain",
+			};
+
+			response = new Response(body, {
+				headers,
+				status: 200,
+			});
+
+			app = {
+				setCookieHeaders: vi.fn(() => [
+					"newCookie=newValue",
+					"deleteCookie=deleted; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+				]),
+			} as unknown as App;
+
+			fnResponse = await createLambdaEdgeFunctionResponse(app, response, knownBinaryMediaTypes);
+		});
+
+		test("creates function response", () => {
+			expect(app.setCookieHeaders).toHaveBeenCalledTimes(1);
+			expect(app.setCookieHeaders).toHaveBeenCalledWith(response);
+
+			expect(fnResponse).toStrictEqual({
+				body,
+				bodyEncoding: "text",
+				headers: {
+					"content-type": [
+						{
+							key: "content-type",
+							value: "text/plain",
+						},
+					],
+					"set-cookie": [
+						{
+							key: "set-cookie",
+							value: "newCookie=newValue",
+						},
+						{
+							key: "set-cookie",
+							value: "deleteCookie=deleted; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+						},
+					],
+				},
+				status: "200",
+				statusDescription: "",
 			});
 		});
 	});


### PR DESCRIPTION
<!--
For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)
-->

| Q                       | A <!--(Can use an emoji 👍) -->                                                                            |
| ----------------------- | ---------------------------------------------------------------------------------------------------------- |
| Fixed Issues?           | Fixes #63 |
| Patch: Bug Fix?         | Bug Fix
| Major: Breaking Change? | Use Astro.cookies instead of Astro.response.headers.set('set-cookie')
| Minor: New Feature?     | Astro.cookies now respected in LambdaEdge response
| Tests Added + Pass?     | Yes                                                                                                        |
| Documentation PR Link   | <!-- If only readme change, add `[skip ci]` to your commits -->                                            |
| Any Dependency Changes? |
| License                 | MIT                                                                                                        |

Cookies set via Astro.cookies are now set in the LambdaEdge response.
One can still set a 'Set-Cookie' header directly, but cookies set via Astro.cookies will take precedence and would overwrite the directly set 'Set-Cookie' header. 

---
Scenario 1:
```
Astro.response.headers.set('Set-Cookie', 'test=test')
````

Response headers:  
```
'Set-Cookie': 'test=test'
```
---

Scenario 2:
```
Astro.cookies.set('test', 'test')
Astro.cookies.delete('otherCookie')
````

Response headers:  
```
'Set-Cookie': 'test=test'
'Set-Cookie': 'otherCookie=deleted; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
```
---

Scenario 3:
```
Astro.response.headers.set('Set-Cookie', 'manual=test')
Astro.cookies.set('viaAstro', 'test')
````

Response headers:  
```
'Set-Cookie': 'viaAstro=test'
```