### PR TITLE
fix: allow extending the js banner

### DIFF
--- a/packages/adapter/src/shared.ts
+++ b/packages/adapter/src/shared.ts
@@ -13,21 +13,26 @@ const DEFAULT_CONFIG: BuildOptions = {
 	target: "node16",
 };
 
-export const createEsBuildConfig = (entryFile: string, outDir: string, { esBuildOptions = {} }: Args) =>
-	mergeAndConcat(DEFAULT_CONFIG, esBuildOptions, {
-		banner: {
-			js: [
-				"import { createRequire as topLevelCreateRequire } from 'module';",
-				"const require = topLevelCreateRequire(import.meta.url);",
-			].join(""),
-		},
-		entryPoints: [entryFile],
-		format: "esm",
-		outdir: outDir,
-		outExtension: {
-			".js": ".mjs",
-		},
-	}) as BuildOptions;
+export const createEsBuildConfig = (
+  entryFile: string,
+  outDir: string,
+  { esBuildOptions = {} }: Args
+) =>
+  mergeAndConcat(DEFAULT_CONFIG, esBuildOptions, {
+    banner: {
+      js: [
+        "import { createRequire as topLevelCreateRequire } from 'module';",
+        'const require = topLevelCreateRequire(import.meta.url);',
+        esBuildOptions.banner?.js ?? '',
+      ].join(''),
+    },
+    entryPoints: [entryFile],
+    format: 'esm',
+    outdir: outDir,
+    outExtension: {
+      '.js': '.mjs',
+    },
+  }) as BuildOptions
 
 export const bundleEntry = async (entryFile: string, outDir: string, args: Args) => {
 	await build(createEsBuildConfig(entryFile, outDir, args));


### PR DESCRIPTION
This PR to allow to extend the js banner to answer scenarios such as:
- need to add `__dirname` or any kind of polyfill
- need to pass env vars with `Object.assign(process.env, arbitraryJson)`