### PR TITLE
fix: prepare for astro 5.0

### DIFF
--- a/packages/adapter/src/lambda/handlers/edge.ts
+++ b/packages/adapter/src/lambda/handlers/edge.ts
@@ -94,7 +94,7 @@ const createExports = (
 			return def
 		}
 
-		const response = await app.render(request, routeData, args.locals)
+		const response = await app.render(request, { routeData, locals: args.locals })
 		const fnResponse = await createLambdaEdgeFunctionResponse(
 			app,
 			response,

--- a/packages/adapter/src/lambda/handlers/ssr.ts
+++ b/packages/adapter/src/lambda/handlers/ssr.ts
@@ -157,7 +157,7 @@ const createExports = (
 			}
 		}
 
-		const response = await app.render(request, routeData, args.locals)
+		const response = await app.render(request, { routeData, locals: args.locals })
 
 		return createLambdaFunctionResponse(
 			app,


### PR DESCRIPTION
remove warning:

[deprecated] The adapter @astro-aws/adapter is using a deprecated signature of the 'app.render()' method. From Astro 4.0, locals and routeData are provided as properties on an optional object to this method. Using the old signature will cause an error in Astro 5.0. See https://github.com/withastro/astro/pull/9199 for more information.