### PR TITLE
Ensure S3 bucket options are properly propagated

### DIFF
--- a/.changeset/blue-carpets-deny.md
+++ b/.changeset/blue-carpets-deny.md
@@ -1,0 +1,5 @@
+---
+"@astro-aws/constructs": patch
+---
+
+Fixed circular reference in S3 bucket construct which prevented configuration of the S3 part of the infrastructure.

--- a/packages/constructs/src/constructs/astro-aws-s3-bucket.ts
+++ b/packages/constructs/src/constructs/astro-aws-s3-bucket.ts
@@ -44,7 +44,7 @@ class AstroAWSS3Bucket extends AstroAWSBaseConstruct<
 			blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
 			encryption: BucketEncryption.S3_MANAGED,
 			enforceSSL: true,
-			...this.cdk.s3Bucket,
+			...props.cdk?.s3Bucket,
 		})
 
 		this.#originAccessIdentity = new OriginAccessIdentity(this, "S3BucketOAI", {


### PR DESCRIPTION
Thanks for creating this handy project! I found it useful, and would like to help out by fixing a bug I found while using it.

| Q                       | A <!--(Can use an emoji 👍) -->                                                                            |
| ----------------------- | ---------------------------------------------------------------------------------------------------------- |
| Fixed Issues?           | |
| Patch: Bug Fix?         | Yes |
| Major: Breaking Change? | Possible, explained below |
| Minor: New Feature?     |
| Tests Added + Pass?     |                                                                                                    |
| Documentation PR Link   |                                        |
| Any Dependency Changes? |
| License                 | MIT                                                                                                        |

In the below context:

https://github.com/lukeshay/astro-aws/blob/5a667bef0e852e4c547b8586e04ba8f47bcf363b/packages/constructs/src/constructs/astro-aws-s3-bucket.ts#L43-L48

`this.cdk.s3Bucket` references this getter:

https://github.com/lukeshay/astro-aws/blob/5a667bef0e852e4c547b8586e04ba8f47bcf363b/packages/constructs/src/constructs/astro-aws-s3-bucket.ts#L67-L72

This is most likely a typo, as it causes a circular dependency (`this.#s3Bucket` -> `this.cdk` -> `this.#s3Bucket` etc.).
The result is that it currently isn't possible to set options for the created S3 bucket, such as its name.

This is **possibly** a breaking change because users of this construct _may_ have previously added options to the `cdk.s3Bucket` property. So far, that would have had no effect - but with these changes, they will be applied during the next deployment which might cause unexpected changes.

