### PR TITLE
(docs): fix docs references based on cdk types

### DIFF
--- a/apps/docs/src/content/docs/guides/02-query-parameters.md
+++ b/apps/docs/src/content/docs/guides/02-query-parameters.md
@@ -39,7 +39,9 @@ export class HelloCdkStack extends Stack {
 				},
 				// This configures everything excluding subpaths of /api.
 				cloudfrontDistribution: {
-					cachePolicy,
+					defaultBehavior: {
+						cachePolicy,
+					},
 				},
 			},
 			websiteDir: "../my-astro-project",

--- a/apps/docs/src/content/docs/guides/03-cookies.md
+++ b/apps/docs/src/content/docs/guides/03-cookies.md
@@ -36,7 +36,9 @@ export class HelloCdkStack extends Stack {
 				},
 				// This configures everything excluding subpaths of /api.
 				cloudfrontDistribution: {
-					cachePolicy,
+					defaultBehavior: {
+						cachePolicy,
+					},
 				},
 			},
 			websiteDir: "../my-astro-project",


### PR DESCRIPTION

| Q                       | A <!--(Can use an emoji 👍) -->                                                                            |
| ----------------------- | ---------------------------------------------------------------------------------------------------------- |
| Fixed Issues?           | No |
| Patch: Bug Fix?         | No|
| Major: Breaking Change? | No |
| Minor: New Feature?     | No |
| Tests Added + Pass?     | No |                                                                                                        |
| Documentation PR Link   | <!-- If only readme change, add `[skip ci]` to your commits -->                                            |
| Any Dependency Changes? |
| License                 | MIT                                                                                                        |

It is a docs fix based on cdk types:
https://github.com/lukeshay/astro-aws/blob/f6b49f11c22975e19e090d3f8f6cf3095f554435/apps/infra/src/lib/stacks/website-stack.ts#L107-L115
