### PR TITLE
chore(adapter): remove @astrojs/webapi polyfill

### DIFF
--- a/.changeset/hot-peas-rush.md
+++ b/.changeset/hot-peas-rush.md
@@ -1,0 +1,5 @@
+---
+"@astro-aws/adapter": patch
+---
+
+Remove @astrojs/webapi polyfill

--- a/apps/infra/cdk.context.json
+++ b/apps/infra/cdk.context.json
@@ -1,13 +1,11 @@
 {
-  "acknowledged-issue-numbers": [
-    34892
-  ],
-  "hosted-zone:account=738697399292:domainName=astro-aws.org:region=us-east-1": {
-    "Id": "/hostedzone/Z0584480MGUI8KRBPWM",
-    "Name": "astro-aws.org."
-  },
-  "hosted-zone:account=738697399292:domainName=astro-aws.org:region=us-west-2": {
-    "Id": "/hostedzone/Z0584480MGUI8KRBPWM",
-    "Name": "astro-aws.org."
-  }
+	"acknowledged-issue-numbers": [34892],
+	"hosted-zone:account=738697399292:domainName=astro-aws.org:region=us-east-1": {
+		"Id": "/hostedzone/Z0584480MGUI8KRBPWM",
+		"Name": "astro-aws.org."
+	},
+	"hosted-zone:account=738697399292:domainName=astro-aws.org:region=us-west-2": {
+		"Id": "/hostedzone/Z0584480MGUI8KRBPWM",
+		"Name": "astro-aws.org."
+	}
 }

--- a/bun.lock
+++ b/bun.lock
@@ -83,9 +83,8 @@
     },
     "packages/adapter": {
       "name": "@astro-aws/adapter",
-      "version": "0.13.1",
+      "version": "1.0.0-RC.0",
       "dependencies": {
-        "@astrojs/webapi": "^3.0.0",
         "@middy/core": "^6.4.5",
         "esbuild": "^0.28.1",
         "flatted": "^3.4.2",
@@ -109,7 +108,7 @@
     },
     "packages/constructs": {
       "name": "@astro-aws/constructs",
-      "version": "0.13.1",
+      "version": "1.0.0-RC.0",
       "dependencies": {
         "flatted": "^3.4.2",
       },
@@ -196,8 +195,6 @@
     "@astrojs/starlight": ["@astrojs/starlight@0.38.5", "", { "dependencies": { "@astrojs/markdown-remark": "^7.1.1", "@astrojs/mdx": "^5.0.4", "@astrojs/sitemap": "^3.7.2", "@pagefind/default-ui": "^1.3.0", "@types/hast": "^3.0.4", "@types/js-yaml": "^4.0.9", "@types/mdast": "^4.0.4", "astro-expressive-code": "^0.42.0", "bcp-47": "^2.1.0", "hast-util-from-html": "^2.0.3", "hast-util-select": "^6.0.4", "hast-util-to-string": "^3.0.1", "hastscript": "^9.0.1", "i18next": "^23.11.5", "js-yaml": "^4.1.1", "klona": "^2.0.6", "magic-string": "^0.30.21", "mdast-util-directive": "^3.1.0", "mdast-util-to-markdown": "^2.1.2", "mdast-util-to-string": "^4.0.0", "pagefind": "^1.3.0", "rehype": "^13.0.2", "rehype-format": "^5.0.1", "remark-directive": "^4.0.0", "ultrahtml": "^1.6.0", "unified": "^11.0.5", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "astro": "^6.0.0" } }, "sha512-35xLSOtZDAMAilHG2zAEZoJ4AaPb+doYOvxuuRTAnmIBSOvujffOAHv3/rr6W/LJtkhBU38PjRDJ4i8QT1uGVw=="],
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.2", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ=="],
-
-    "@astrojs/webapi": ["@astrojs/webapi@3.0.0", "", { "dependencies": { "undici": "^5.22.1" } }, "sha512-+/Wruju2Ho99z0jI8zxMFGBkKKG97RzR/srSaColejUDrczkAjR3HjULKTVfDdIpvtvFZLyl7OMBmHKQazfeZg=="],
 
     "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.4", "", { "dependencies": { "yaml": "^2.8.3" } }, "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A=="],
 
@@ -418,8 +415,6 @@
     "@expressive-code/plugin-text-markers": ["@expressive-code/plugin-text-markers@0.42.0", "", { "dependencies": { "@expressive-code/core": "^0.42.0" } }, "sha512-l59lUx8fq1v5g6SpmbDjiU0+7IdfbiWnAyRmtTVSpfhyq+nZMN4UcmYyu2b9Mynhzt7Gr+O+cXyEPDNb2AVWVQ=="],
 
     "@faker-js/faker": ["@faker-js/faker@10.4.0", "", {}, "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw=="],
-
-    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -1992,8 +1987,6 @@
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
-
-    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -57,7 +57,6 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@astrojs/webapi": "^3.0.0",
 		"@middy/core": "^6.4.5",
 		"esbuild": "^0.28.1",
 		"flatted": "^3.4.2",

--- a/packages/adapter/src/lambda/handlers/edge.ts
+++ b/packages/adapter/src/lambda/handlers/edge.ts
@@ -8,7 +8,6 @@ import type {
 	CloudFrontResponseResult,
 } from "aws-lambda"
 import { type SSRManifest } from "astro"
-import { polyfill } from "@astrojs/webapi"
 
 import type { Args } from "../../args.js"
 import { createRequestBody, parseContentType, validateURL } from "../helpers.js"
@@ -18,10 +17,6 @@ import {
 } from "../constants.js"
 import { withLogger } from "../middleware.js"
 import { createApp } from "astro/app/entrypoint"
-
-polyfill(globalThis, {
-	exclude: "window document",
-})
 
 const app = createApp({
 	streaming: false,

--- a/packages/adapter/src/lambda/handlers/ssr.ts
+++ b/packages/adapter/src/lambda/handlers/ssr.ts
@@ -7,7 +7,6 @@ import type {
 } from "aws-lambda"
 import middy, { MiddyfiedHandler } from "@middy/core"
 import { type SSRManifest } from "astro"
-import { polyfill } from "@astrojs/webapi"
 
 import type { Args } from "../../args.js"
 import {
@@ -21,10 +20,6 @@ import { KNOWN_BINARY_MEDIA_TYPES } from "../constants.js"
 import { type CloudfrontResult } from "../types.js"
 import { createApp } from "astro/app/entrypoint"
 import { BaseApp, AppPipeline } from "astro/app"
-
-polyfill(globalThis, {
-	exclude: "window document",
-})
 
 const originalFetch = globalThis.fetch.bind(globalThis)
 


### PR DESCRIPTION
## Summary

Remove the `@astrojs/webapi` polyfill dependency from the adapter. Node 22+ (now required) natively provides all Web APIs that were being polyfilled.

## Changes

- Remove `polyfill` import and call from `ssr.ts`
- Remove `polyfill` import and call from `edge.ts`
- Remove `@astrojs/webapi` from `package.json` dependencies

## Why

Node 22 natively provides everything `@astrojs/webapi` was patching onto `globalThis`: `fetch`, `Request`, `Response`, `Headers`, `URL`, `crypto`, streams, `structuredClone`, etc. The polyfill is redundant and adds unnecessary bundle weight and cold-start overhead.

Removing it also eliminates `undici@5` and `@fastify/busboy` as transitive dependencies, reducing supply chain attack surface.

> The custom `globalThis.fetch` override for local `/_astro/` asset serving is preserved — that is application logic, not a polyfill.

## Testing

All 20 tests pass without modification — the test suite already ran on Node 22 without the polyfill.