### PR TITLE
docs: note Lambda function URL region support

### DIFF
--- a/apps/docs/src/content/docs/start-here/getting-started.mdx
+++ b/apps/docs/src/content/docs/start-here/getting-started.mdx
@@ -19,6 +19,7 @@ Before you begin, make sure you have the following:
 - **AWS Account** with appropriate permissions
 - **AWS CLI** installed and configured with your credentials
 - **AWS CDK CLI** (we'll install this in the guide)
+- **AWS Region** that supports [Lambda function URLs](https://docs.aws.amazon.com/lambda/latest/dg/urls-configuration.html)
 
 ## Step 1: Create your Astro project
 
@@ -175,6 +176,8 @@ export class AstroSiteStack extends Stack {
 > **Note:** Update `websiteDir` to point to the relative path of your Astro project from the CDK project directory. The construct will look for the `dist` directory inside this path.
 
 ## Step 4: Bootstrap AWS CDK (first time only)
+
+Before bootstrapping, confirm that your configured AWS region supports Lambda function URLs. Deployments to unsupported regions fail with an `Unrecognized resource types: [AWS::Lambda::Url]` error.
 
 If this is your first time using AWS CDK in this account and region, you need to bootstrap it:
 


### PR DESCRIPTION
# Context

Fixes #180

The Getting Started guide did not mention that deployments require an AWS region with Lambda function URL support. In unsupported regions, users can bootstrap CDK before discovering that the stack cannot deploy.

# Additional Changes Made

- Adds Lambda function URL support to the prerequisites.
- Adds a warning before CDK bootstrapping with the expected `AWS::Lambda::Url` error.
- Links to the AWS Lambda function URL documentation.

# TODO

- [x] Added unit tests (not applicable for a documentation-only change)
- [x] Updated or added new documentation to [documentation website](apps/docs)

## Validation

- Prettier check passes for the changed MDX file.
- `git diff --check` passes.
- The linked AWS documentation returns HTTP 200.
