### PR TITLE
Remove middy usage

### DIFF
--- a/.changeset/remove-middy-usage.md
+++ b/.changeset/remove-middy-usage.md
@@ -1,0 +1,5 @@
+---
+"@astro-aws/adapter": patch
+---
+
+Remove @middy/core and use native Lambda response streaming

--- a/bun.lock
+++ b/bun.lock
@@ -84,9 +84,8 @@
     },
     "packages/adapter": {
       "name": "@astro-aws/adapter",
-      "version": "1.0.0-RC.0",
+      "version": "1.0.0",
       "dependencies": {
-        "@middy/core": "^6.4.5",
         "esbuild": "^0.28.1",
         "flatted": "^3.4.2",
         "http-status-codes": "^2.3.0",
@@ -109,7 +108,7 @@
     },
     "packages/constructs": {
       "name": "@astro-aws/constructs",
-      "version": "1.0.0-RC.0",
+      "version": "1.0.0",
       "dependencies": {
         "flatted": "^3.4.2",
       },
@@ -494,8 +493,6 @@
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
-
-    "@middy/core": ["@middy/core@6.4.5", "", {}, "sha512-qRGCslDHjMr08fywcfVbWR9qpx16vGD481i9GpX3r5efi8Arjp/44JTjfeJkJJxvIb/8/+E9MLvU86+3oe1oJQ=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -57,7 +57,6 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@middy/core": "^6.4.5",
 		"esbuild": "^0.28.1",
 		"flatted": "^3.4.2",
 		"http-status-codes": "^2.3.0",

--- a/packages/adapter/src/lambda/awslambda.d.ts
+++ b/packages/adapter/src/lambda/awslambda.d.ts
@@ -1,0 +1,23 @@
+import type { Writable } from "node:stream"
+
+import type { Context } from "aws-lambda"
+
+declare const awslambda: {
+	HttpResponseStream: {
+		from(
+			responseStream: Writable,
+			metadata: {
+				statusCode?: number
+				headers?: Record<string, string | number | boolean>
+				cookies?: string[]
+			},
+		): Writable
+	}
+	streamifyResponse<TEvent>(
+		handler: (
+			event: TEvent,
+			responseStream: Writable,
+			context: Context,
+		) => Promise<void> | void,
+	): (event: TEvent, context: Context) => Promise<void>
+}

--- a/packages/adapter/src/lambda/handlers/ssr.ts
+++ b/packages/adapter/src/lambda/handlers/ssr.ts
@@ -5,7 +5,6 @@ import type {
 	APIGatewayProxyEventV2,
 	APIGatewayProxyHandlerV2,
 } from "aws-lambda"
-import middy, { MiddyfiedHandler } from "@middy/core"
 import { setGetEnv } from "astro/env/setup"
 import { createApp } from "astro/app/entrypoint"
 
@@ -17,6 +16,7 @@ import {
 	validateURL,
 } from "../helpers.js"
 import { withLogger } from "../middleware.js"
+import { streamifyResponse, type CloudfrontHandler } from "../streamify-response.js"
 import { KNOWN_BINARY_MEDIA_TYPES } from "../constants.js"
 import { type CloudfrontResult } from "../types.js"
 import {
@@ -293,8 +293,14 @@ const lambdaHandler: APIGatewayProxyHandlerV2<CloudfrontResult> = async (
 	)
 }
 
-const handler = middy({ streamifyResponse: shouldStream }).handler(
-	withLogger(adapterLogger, loggerOptions, lambdaHandler) as MiddyfiedHandler,
+const loggedHandler = withLogger(
+	adapterLogger,
+	loggerOptions,
+	lambdaHandler,
 )
+
+const handler = shouldStream
+	? streamifyResponse(loggedHandler as CloudfrontHandler)
+	: loggedHandler
 
 export { handler }

--- a/packages/adapter/src/lambda/streamify-response.ts
+++ b/packages/adapter/src/lambda/streamify-response.ts
@@ -1,0 +1,39 @@
+import { Readable } from "node:stream"
+import { pipeline } from "node:stream/promises"
+
+import type { APIGatewayProxyEventV2, Context } from "aws-lambda"
+
+import { type CloudfrontResult } from "./types.js"
+
+type CloudfrontHandler = (
+	event: APIGatewayProxyEventV2,
+	context: Context,
+) => Promise<CloudfrontResult>
+
+const streamifyResponse = (handler: CloudfrontHandler) =>
+	awslambda.streamifyResponse<APIGatewayProxyEventV2>(
+		async (event, responseStream, context: Context) => {
+			const result = await handler(event, context)
+
+			const metadata = {
+				cookies: result.cookies,
+				headers: result.headers,
+				statusCode: result.statusCode,
+			}
+
+			const httpResponseStream = awslambda.HttpResponseStream.from(
+				responseStream,
+				metadata,
+			)
+
+			if (result.body instanceof Readable) {
+				await pipeline(result.body, httpResponseStream)
+				return
+			}
+
+			httpResponseStream.write(result.body)
+			httpResponseStream.end()
+		},
+	)
+
+export { type CloudfrontHandler, streamifyResponse }

--- a/packages/adapter/src/lambda/streamify-response.ts
+++ b/packages/adapter/src/lambda/streamify-response.ts
@@ -1,14 +1,19 @@
-import { Readable } from "node:stream"
+import { type Readable } from "node:stream"
 import { pipeline } from "node:stream/promises"
 
 import type { APIGatewayProxyEventV2, Context } from "aws-lambda"
 
 import { type CloudfrontResult } from "./types.js"
 
+/** Streaming handlers must return a Readable body; string bodies are not supported. */
+type CloudfrontStreamingResult = Omit<CloudfrontResult, "body"> & {
+	body: Readable
+}
+
 type CloudfrontHandler = (
 	event: APIGatewayProxyEventV2,
 	context: Context,
-) => Promise<CloudfrontResult>
+) => Promise<CloudfrontStreamingResult>
 
 const streamifyResponse = (handler: CloudfrontHandler) =>
 	awslambda.streamifyResponse<APIGatewayProxyEventV2>(
@@ -26,13 +31,12 @@ const streamifyResponse = (handler: CloudfrontHandler) =>
 				metadata,
 			)
 
-			if (result.body instanceof Readable) {
-				await pipeline(result.body, httpResponseStream)
-				return
-			}
+			// HttpResponseStream only flushes the metadata frame on the first
+			// write. Empty bodies (redirects, 204) emit no chunks through
+			// pipeline, so force a prelude write before ending.
+			httpResponseStream.write("")
 
-			httpResponseStream.write(result.body)
-			httpResponseStream.end()
+			await pipeline(result.body, httpResponseStream)
 		},
 	)
 

--- a/packages/adapter/test/lambda/handlers/ssr-stream.test.ts
+++ b/packages/adapter/test/lambda/handlers/ssr-stream.test.ts
@@ -27,13 +27,19 @@ const { mockFrom, mockStreamifyResponse } = vi.hoisted(() => {
 				cookies?: string[]
 			},
 		) => {
+			const chunks: unknown[] = []
 			const httpResponseStream = new Writable({
-				write(_chunk, _encoding, callback) {
+				write(chunk, _encoding, callback) {
+					chunks.push(chunk)
 					callback()
 				},
 			})
 
-			Object.assign(httpResponseStream, { metadata, responseStream })
+			Object.assign(httpResponseStream, {
+				chunks,
+				metadata,
+				responseStream,
+			})
 
 			return httpResponseStream
 		},
@@ -146,9 +152,41 @@ describe("ssr-stream", () => {
 				statusCode: 200,
 			}),
 		)
+
+		const httpResponseStream = mockFrom.mock.results[0]?.value as Writable & {
+			chunks: unknown[]
+		}
+		expect(httpResponseStream.chunks[0]?.toString()).toBe("")
 	})
 
-	test("writes string bodies when the handler returns a non-readable body", async () => {
+	test("writes a prelude chunk for empty bodies so metadata is flushed", async () => {
+		mockRender.mockResolvedValue(
+			new Response(null, {
+				headers: { location: "https://example.com/" },
+				status: 302,
+			}),
+		)
+
+		const { handler } = await import("../../../src/lambda/handlers/ssr.js")
+
+		await (handler as Function)(createMockEvent(), {})
+
+		expect(mockFrom).toHaveBeenCalledWith(
+			expect.any(Writable),
+			expect.objectContaining({
+				headers: { location: "https://example.com/" },
+				statusCode: 302,
+			}),
+		)
+
+		const httpResponseStream = mockFrom.mock.results[0]?.value as Writable & {
+			chunks: unknown[]
+		}
+		expect(httpResponseStream.chunks.length).toBeGreaterThan(0)
+		expect(httpResponseStream.chunks[0]?.toString()).toBe("")
+	})
+
+	test("streams 404 responses with a prelude write", async () => {
 		mockMatch.mockReturnValue(undefined)
 
 		const { handler } = await import("../../../src/lambda/handlers/ssr.js")
@@ -162,6 +200,11 @@ describe("ssr-stream", () => {
 				statusCode: 404,
 			}),
 		)
+
+		const httpResponseStream = mockFrom.mock.results[0]?.value as Writable & {
+			chunks: unknown[]
+		}
+		expect(httpResponseStream.chunks[0]?.toString()).toBe("")
 	})
 
 	test("enables Astro streaming when mode is ssr-stream", async () => {

--- a/packages/adapter/test/lambda/handlers/ssr-stream.test.ts
+++ b/packages/adapter/test/lambda/handlers/ssr-stream.test.ts
@@ -1,0 +1,174 @@
+import { Writable } from "node:stream"
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockMatch, mockRender, mockSetGetEnv, runtimeConfig } = vi.hoisted(
+	() => ({
+		mockMatch: vi.fn(),
+		mockRender: vi.fn(),
+		mockSetGetEnv: vi.fn(),
+		runtimeConfig: {
+			binaryMediaTypes: [] as string[],
+			includeRequestIdInLocals: false,
+			locals: {} as Record<string, unknown>,
+			logger: undefined,
+			mode: "ssr-stream" as const,
+		},
+	}),
+)
+
+const { mockFrom, mockStreamifyResponse } = vi.hoisted(() => {
+	const mockFrom = vi.fn(
+		(
+			responseStream: Writable,
+			metadata: {
+				statusCode?: number
+				headers?: Record<string, string>
+				cookies?: string[]
+			},
+		) => {
+			const httpResponseStream = new Writable({
+				write(_chunk, _encoding, callback) {
+					callback()
+				},
+			})
+
+			Object.assign(httpResponseStream, { metadata, responseStream })
+
+			return httpResponseStream
+		},
+	)
+
+	const mockStreamifyResponse = vi.fn(
+		(
+			handler: (
+				event: unknown,
+				responseStream: Writable,
+				context: unknown,
+			) => Promise<void>,
+		) =>
+			async (event: unknown, context: unknown) => {
+				const responseStream = new Writable({
+					write(_chunk, _encoding, callback) {
+						callback()
+					},
+				})
+
+				await handler(event, responseStream, context)
+			},
+	)
+
+	return { mockFrom, mockStreamifyResponse }
+})
+
+vi.stubGlobal("awslambda", {
+	HttpResponseStream: { from: mockFrom },
+	streamifyResponse: mockStreamifyResponse,
+})
+
+vi.mock("astro/env/setup", () => ({
+	setGetEnv: mockSetGetEnv,
+}))
+
+vi.mock("../../../src/load-runtime-config.js", () => ({
+	get binaryMediaTypes() {
+		return runtimeConfig.binaryMediaTypes
+	},
+	get includeRequestIdInLocals() {
+		return runtimeConfig.includeRequestIdInLocals
+	},
+	get locals() {
+		return runtimeConfig.locals
+	},
+	get logger() {
+		return runtimeConfig.logger
+	},
+	get mode() {
+		return runtimeConfig.mode
+	},
+}))
+
+vi.mock("astro/app/entrypoint", () => ({
+	createApp: vi.fn(() => ({
+		adapterLogger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+		manifest: {},
+		match: mockMatch,
+		render: mockRender,
+		setCookieHeaders: () => ["session=abc"],
+	})),
+}))
+
+const createMockEvent = () => ({
+	body: undefined,
+	cookies: undefined,
+	headers: {},
+	isBase64Encoded: false,
+	rawPath: "/test",
+	rawQueryString: "",
+	requestContext: {
+		domainName: "example.com",
+		http: { method: "GET", sourceIp: "203.0.113.10" },
+		requestId: "req-001",
+	},
+})
+
+describe("ssr-stream", () => {
+	beforeEach(async () => {
+		vi.clearAllMocks()
+		vi.resetModules()
+		mockMatch.mockReturnValue({ route: "/test" })
+	})
+
+	test("wraps the handler with awslambda.streamifyResponse", async () => {
+		const { handler } = await import("../../../src/lambda/handlers/ssr.js")
+
+		expect(mockStreamifyResponse).toHaveBeenCalledOnce()
+		expect(handler).toBeTypeOf("function")
+	})
+
+	test("streams response metadata and readable body through HttpResponseStream", async () => {
+		mockRender.mockResolvedValue(
+			new Response("streamed body", {
+				headers: { "content-type": "text/html" },
+				status: 200,
+			}),
+		)
+
+		const { handler } = await import("../../../src/lambda/handlers/ssr.js")
+
+		await (handler as Function)(createMockEvent(), {})
+
+		expect(mockFrom).toHaveBeenCalledWith(
+			expect.any(Writable),
+			expect.objectContaining({
+				cookies: ["session=abc"],
+				headers: { "content-type": "text/html" },
+				statusCode: 200,
+			}),
+		)
+	})
+
+	test("writes string bodies when the handler returns a non-readable body", async () => {
+		mockMatch.mockReturnValue(undefined)
+
+		const { handler } = await import("../../../src/lambda/handlers/ssr.js")
+
+		await (handler as Function)(createMockEvent(), {})
+
+		expect(mockFrom).toHaveBeenCalledWith(
+			expect.any(Writable),
+			expect.objectContaining({
+				headers: { "content-type": "text/plain" },
+				statusCode: 404,
+			}),
+		)
+	})
+
+	test("enables Astro streaming when mode is ssr-stream", async () => {
+		const { createApp } = await import("astro/app/entrypoint")
+
+		await import("../../../src/lambda/handlers/ssr.js")
+
+		expect(createApp).toHaveBeenCalledWith({ streaming: true })
+	})
+})


### PR DESCRIPTION
## Summary
- Replace `@middy/core` with a native `awslambda.streamifyResponse` / `HttpResponseStream.from` helper for `ssr-stream` mode
- Keep buffered `ssr` mode on a plain `withLogger` handler (same pattern as edge)
- Add streaming-mode unit tests and a patch changeset for `@astro-aws/adapter`

Closes #165

## Test plan
- [x] `bun run test` in `packages/adapter` (28 tests passing)
- [x] `bun run build` in `packages/adapter`
- [ ] Confirm no remaining `@middy` references in the repo
- [ ] Smoke-test an `ssr-stream` deploy against a Function URL with `RESPONSE_STREAM` if desired


Made with [Cursor](https://cursor.com)