### PR TITLE
fix: emit every Set-Cookie header from Lambda and Lambda@Edge responses

### DIFF
--- a/.changeset/set-cookie-headers-fix.md
+++ b/.changeset/set-cookie-headers-fix.md
@@ -1,0 +1,5 @@
+---
+"@astro-aws/adapter": patch
+---
+
+Emit every set-cookie header from lambda and edge responses. Previously, cookies set directly on the response headers (rather than via `Astro.cookies`) were ignored.

--- a/packages/adapter/src/lambda/handlers/edge.ts
+++ b/packages/adapter/src/lambda/handlers/edge.ts
@@ -38,7 +38,7 @@ const createLambdaEdgeFunctionResponse = async (
 	knownBinaryMediaTypes: Set<string>,
 	readOnlyHeaders: Array<RegExp>,
 ): Promise<CloudFrontRequestResult | CloudFrontResponseResult> => {
-	const cookies = [...app.setCookieHeaders(response)]
+	const cookies = response.headers.getSetCookie()
 
 	const responseHeadersObj = Object.fromEntries(response.headers.entries())
 
@@ -47,6 +47,7 @@ const createLambdaEdgeFunctionResponse = async (
 			Object.entries(responseHeadersObj)
 				.filter(
 					([key]) =>
+						key.toLowerCase() !== "set-cookie" &&
 						!readOnlyHeaders.some((reg) => reg.test(key.toLowerCase())),
 				)
 				.map(([key, value]) => [
@@ -103,6 +104,7 @@ const handleRequest = async (
 		}
 	}
 	const response = await app.render(request, {
+		addCookieHeader: true,
 		clientAddress,
 		locals,
 		routeData,

--- a/packages/adapter/src/lambda/handlers/ssr.ts
+++ b/packages/adapter/src/lambda/handlers/ssr.ts
@@ -100,7 +100,7 @@ const createLambdaFunctionHeaders = (
 	response: Response,
 	knownBinaryMediaTypes: Set<string>,
 ) => {
-	const cookies = [...app.setCookieHeaders(response)]
+	const cookies = response.headers.getSetCookie()
 	const intermediateHeaders = new Headers(response.headers)
 
 	intermediateHeaders.delete("set-cookie")
@@ -278,6 +278,7 @@ const lambdaHandler: APIGatewayProxyHandlerV2<CloudfrontResult> = async (
 		}
 	}
 	const response = await app.render(request, {
+		addCookieHeader: true,
 		clientAddress: getClientAddress(
 			headers,
 			event.requestContext.http.sourceIp,

--- a/packages/adapter/test/lambda/handlers/edge.test.ts
+++ b/packages/adapter/test/lambda/handlers/edge.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
-const { mockMatch, mockRender } = vi.hoisted(() => ({
+const { mockMatch, mockRender, mockSetCookieHeaders } = vi.hoisted(() => ({
 	mockMatch: vi.fn(),
 	mockRender: vi.fn(),
+	mockSetCookieHeaders: vi.fn((): string[] => []),
 }))
 
 vi.mock("../../../src/load-runtime-config.js", () => ({
@@ -18,7 +19,7 @@ vi.mock("astro/app/entrypoint", () => ({
 		adapterLogger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 		match: mockMatch,
 		render: mockRender,
-		setCookieHeaders: () => [],
+		setCookieHeaders: mockSetCookieHeaders,
 	})),
 }))
 
@@ -53,6 +54,83 @@ const createMockEvent = () => ({
 describe("edge", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+	})
+
+	describe("cookies", () => {
+		beforeEach(() => {
+			mockMatch.mockReturnValue({ route: "/test" })
+		})
+
+		test("emits every set-cookie response header as a separate entry", async () => {
+			mockRender.mockResolvedValue(
+				new Response("OK", {
+					headers: [
+						["content-type", "text/html"],
+						["set-cookie", "a=1"],
+						["set-cookie", "b=2"],
+					],
+					status: 200,
+				}),
+			)
+
+			const result = await (handler as Function)(createMockEvent(), {})
+
+			expect(result.headers["set-cookie"]).toEqual([
+				{ key: "set-cookie", value: "a=1" },
+				{ key: "set-cookie", value: "b=2" },
+			])
+		})
+
+		test("renders with addCookieHeader so Astro.cookies are merged into headers", async () => {
+			mockRender.mockResolvedValue(
+				new Response("OK", {
+					headers: { "content-type": "text/html" },
+					status: 200,
+				}),
+			)
+
+			await (handler as Function)(createMockEvent(), {})
+
+			expect(mockRender).toHaveBeenCalledWith(
+				expect.any(Request),
+				expect.objectContaining({ addCookieHeader: true }),
+			)
+		})
+
+		test("emits no set-cookie header when the response sets none", async () => {
+			mockRender.mockResolvedValue(
+				new Response("OK", {
+					headers: { "content-type": "text/html" },
+					status: 200,
+				}),
+			)
+
+			const result = await (handler as Function)(createMockEvent(), {})
+
+			expect(result.headers).not.toHaveProperty("set-cookie")
+		})
+
+		test("**not** emit setCookieHeaders cookies a second time", async () => {
+			// addCookieHeader: true already merges Astro.cookies into the
+			// response headers, so reading setCookieHeaders as well would
+			// duplicate every cookie set via Astro.cookies.set().
+			mockSetCookieHeaders.mockReturnValueOnce(["sentinel=1"])
+			mockRender.mockResolvedValue(
+				new Response("OK", {
+					headers: [
+						["content-type", "text/html"],
+						["set-cookie", "a=1"],
+					],
+					status: 200,
+				}),
+			)
+
+			const result = await (handler as Function)(createMockEvent(), {})
+
+			expect(result.headers["set-cookie"]).toEqual([
+				{ key: "set-cookie", value: "a=1" },
+			])
+		})
 	})
 
 	describe("clientAddress", () => {

--- a/packages/adapter/test/lambda/handlers/ssr.test.ts
+++ b/packages/adapter/test/lambda/handlers/ssr.test.ts
@@ -1,19 +1,24 @@
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
-const { mockMatch, mockRender, mockSetGetEnv, runtimeConfig } = vi.hoisted(
-	() => ({
-		mockMatch: vi.fn(),
-		mockRender: vi.fn(),
-		mockSetGetEnv: vi.fn(),
-		runtimeConfig: {
-			binaryMediaTypes: [] as string[],
-			includeRequestIdInLocals: false,
-			locals: {} as Record<string, unknown>,
-			logger: undefined,
-			mode: "ssr" as const,
-		},
-	}),
-)
+const {
+	mockMatch,
+	mockRender,
+	mockSetCookieHeaders,
+	mockSetGetEnv,
+	runtimeConfig,
+} = vi.hoisted(() => ({
+	mockMatch: vi.fn(),
+	mockRender: vi.fn(),
+	mockSetCookieHeaders: vi.fn((): string[] => []),
+	mockSetGetEnv: vi.fn(),
+	runtimeConfig: {
+		binaryMediaTypes: [] as string[],
+		includeRequestIdInLocals: false,
+		locals: {} as Record<string, unknown>,
+		logger: undefined,
+		mode: "ssr" as const,
+	},
+}))
 
 vi.mock("astro/env/setup", () => ({
 	setGetEnv: mockSetGetEnv,
@@ -43,7 +48,7 @@ vi.mock("astro/app/entrypoint", () => ({
 		manifest: {},
 		match: mockMatch,
 		render: mockRender,
-		setCookieHeaders: () => [],
+		setCookieHeaders: mockSetCookieHeaders,
 	})),
 }))
 
@@ -130,6 +135,94 @@ describe("ssr", () => {
 				await (handler as Function)(createMockEvent(), {})
 
 				expect(originalLocals).toEqual({ role: "admin" })
+			})
+		})
+
+		describe("cookies", () => {
+			beforeEach(() => {
+				mockMatch.mockReturnValue({ route: "/test" })
+			})
+
+			test("exposes every set-cookie response header as a separate cookie", async () => {
+				mockRender.mockResolvedValue(
+					new Response("OK", {
+						headers: [
+							["content-type", "text/html"],
+							["set-cookie", "a=1"],
+							["set-cookie", "b=2"],
+						],
+						status: 200,
+					}),
+				)
+
+				const result = await (handler as Function)(createMockEvent(), {})
+
+				expect(result.cookies).toEqual(["a=1", "b=2"])
+			})
+
+			test("renders with addCookieHeader so Astro.cookies are merged into headers", async () => {
+				mockRender.mockResolvedValue(
+					new Response("OK", {
+						headers: { "content-type": "text/html" },
+						status: 200,
+					}),
+				)
+
+				await (handler as Function)(createMockEvent(), {})
+
+				expect(mockRender).toHaveBeenCalledWith(
+					expect.any(Request),
+					expect.objectContaining({ addCookieHeader: true }),
+				)
+			})
+
+			test("returns no cookies when the response sets none", async () => {
+				mockRender.mockResolvedValue(
+					new Response("OK", {
+						headers: { "content-type": "text/html" },
+						status: 200,
+					}),
+				)
+
+				const result = await (handler as Function)(createMockEvent(), {})
+
+				expect(result.cookies).toEqual([])
+			})
+
+			test("**not** emit setCookieHeaders cookies a second time", async () => {
+				// addCookieHeader: true already merges Astro.cookies into the
+				// response headers, so reading setCookieHeaders as well would
+				// duplicate every cookie set via Astro.cookies.set().
+				mockSetCookieHeaders.mockReturnValueOnce(["sentinel=1"])
+				mockRender.mockResolvedValue(
+					new Response("OK", {
+						headers: [
+							["content-type", "text/html"],
+							["set-cookie", "a=1"],
+						],
+						status: 200,
+					}),
+				)
+
+				const result = await (handler as Function)(createMockEvent(), {})
+
+				expect(result.cookies).toEqual(["a=1"])
+			})
+
+			test("**not** duplicate cookies into the headers object", async () => {
+				mockRender.mockResolvedValue(
+					new Response("OK", {
+						headers: [
+							["content-type", "text/html"],
+							["set-cookie", "a=1"],
+						],
+						status: 200,
+					}),
+				)
+
+				const result = await (handler as Function)(createMockEvent(), {})
+
+				expect(result.headers).not.toHaveProperty("set-cookie")
 			})
 		})
 


### PR DESCRIPTION
# Context

Cookies written directly to `response.headers` - by endpoints, middleware, or auth libraries (`response.headers.append("set-cookie", …)`, `new Response(body, { headers })`) - never reach the browser. Only cookies set via `Astro.cookies.set()` survive.

Astro keeps these two `Set-Cookie` channels separate, and an adapter must merge them. `app.setCookieHeaders(response)` reads only the `Astro.cookies` channel - per Astro's own docs on `RenderOptions.addCookieHeader`, it is the *complement* of the `Set-Cookie` header, not the union. Both handlers read only that channel:

- **Lambda (`ssr.ts` / `ssr-stream.ts`)**: header cookies were deleted from the response headers and never added to the API Gateway `cookies` array — silently dropped.
- **Lambda@Edge (`edge.ts`)**: `Object.fromEntries(response.headers.entries())` keeps only the **last** `set-cookie` value (the WHATWG spec leaves `set-cookie` un-combined during `Headers` iteration, so later entries overwrite earlier ones), and when any `Astro.cookies.set()` cookie existed, the spread overwrote header cookies entirely.

This dates back to #62 / #63 (2023), which added `Astro.cookies` emission for Lambda@Edge - the header channel was never wired up. `@astrojs/node` and the Astro dev server both emit the union of the two channels; this PR brings the adapter to parity.

# TODO

- [x] Added unit tests
- [ ] ~~Updated or added new documentation to [documentation website](apps/docs)~~ - N/A: the docs cover inbound cookie forwarding (CloudFront `CachePolicy`) only; outbound `Set-Cookie` behaviour isn't documented.