### PR TITLE
chore: add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,15 @@
+{
+	"name": "astro-aws",
+	"install": "./.cursor/install.sh",
+	"terminals": [
+		{
+			"name": "example-dev",
+			"command": "cd examples/base && MODE=ssr bunx astro dev --host --port 4321"
+		},
+		{
+			"name": "docs-dev",
+			"command": "cd apps/docs && bunx astro dev --host --port 4322"
+		}
+	],
+	"ports": [4321, 4322]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for the astro-aws monorepo.
+# Ensures the pinned Bun toolchain is present, then installs dependencies
+# and builds all workspaces so the dev servers and type info are ready.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+BUN_VERSION="1.3.5"
+
+# The default image ships Node + npm but not Bun (the pinned package manager).
+# Install it to a user-owned prefix and expose it on the default PATH.
+if ! command -v bun >/dev/null 2>&1 || [ "$(bun --version 2>/dev/null || true)" != "$BUN_VERSION" ]; then
+	npm install -g --prefix "$HOME/.npm-global" "bun@${BUN_VERSION}"
+	sudo ln -sf "$HOME/.npm-global/bin/bun" /usr/local/bin/bun
+	sudo ln -sf "$HOME/.npm-global/bin/bunx" /usr/local/bin/bunx
+fi
+
+bun --version
+
+# Deterministic dependency install against the committed lockfile.
+bun install --frozen-lockfile
+
+# Build every workspace (adapter, constructs, docs, example, infra) so that
+# dev servers and downstream type-checks have their generated dist/ output.
+bun run build


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cursor Cloud Agent development environment for the `astro-aws` Bun + Turbo monorepo so future agents boot with a ready-to-use toolchain and running dev servers. This is a repo-managed environment (the committed `.cursor/environment.json` is the highest-precedence source), so merging this PR activates it for future agents.

### What's included

- `.cursor/environment.json` — declares the environment name, install command, two persistent dev-server terminals, and exposed ports.
- `.cursor/install.sh` — idempotent bootstrap that installs the pinned Bun `1.3.5` toolchain (the default image ships Node/npm but not Bun), runs `bun install --frozen-lockfile`, and `bun run build` for all workspaces.

### Terminals / ports

- `example-dev`: `examples/base` SSR app on port `4321`
- `docs-dev`: Starlight docs site on port `4322`

## Validation

Local VM (pinned CI commands: `bun install`, `bun run build`, `bun run test`, `bun run format`):

| Check | Result |
| --- | --- |
| `bun run build` (5 workspaces) | Passed |
| `bun run test` (adapter + constructs) | Passed |
| `bun run format` (prettier `--check`) | Clean |
| `bun install --frozen-lockfile` (idempotence) | No changes on re-run, tree clean |
| Example SSR (`/rerender`) | 100 faker rows rendered server-side, regenerated per request |
| Docs site (`/`, `/start-here/getting-started/`) | HTTP 200 |

### Draft builds

Both draft builds off this branch `SUCCEEDED`:

- Default base image (from-scratch Bun install): `bun@1.3.5` installed, `1959 packages installed`, `5 successful, 5 total` build tasks.
- Snapshot base: install idempotent, build FULL TURBO.

### Fresh Cloud Agent (booted from the default-image build)

| Check | Result |
| --- | --- |
| `bun --version` / `node --version` | `1.3.5` / `v22.14.0` |
| Generated `dist/` (adapter, constructs, example, docs) | All present |
| `bun install --frozen-lockfile` | No changes, clean tree |
| `bun run test` | 5 files / 33 tests + 1 file / 4 tests, all green |
| Example SSR `GET /` | HTTP 200 |
| `/rerender` row count | 100 rows |
| `/rerender` dynamic SSR | Distinct names per request (`Ada Wisozk` vs `Deborah Monahan`) |

Note: the `synth`/deploy path (`apps/infra` CDK) requires AWS credentials and is intentionally left out of the core dev flow.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-164206e5-5b6a-4dfe-acf4-3012b2323f4c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-164206e5-5b6a-4dfe-acf4-3012b2323f4c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

