### PR TITLE
Add workflow to manually attach changesets to PRs

### DIFF
--- a/.github/workflows/add-changeset.yml
+++ b/.github/workflows/add-changeset.yml
@@ -24,6 +24,12 @@ on:
         required: true
         type: string
 
+# Serialize dispatches that target the same PR so the second job checks out
+# the first job's commit instead of racing to a non-fast-forward push.
+concurrency:
+  group: add-changeset-${{ inputs.pr_number }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -33,14 +39,23 @@ jobs:
     name: Add changeset to PR
     runs-on: ubuntu-22.04
     steps:
+      - name: Require GH_PAT
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_PAT}" ]]; then
+            echo "::error::GH_PAT is required. Pushes with github.token do not trigger pull_request checks (ci.yml / pr.yml)."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
-          # Prefer a PAT so pushes work for maintainer workflows and fork PRs when configured
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ secrets.GH_PAT }}
 
       - name: Checkout pull request branch
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           PR_NUMBER: ${{ inputs.pr_number }}
         run: gh pr checkout "$PR_NUMBER"
 
@@ -53,63 +68,90 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           set -euo pipefail
+          python3 <<'PY'
+          import json
+          import os
+          import pathlib
+          import re
+          import sys
 
-          case "$CHANGE_LEVEL" in
-            major|minor|patch) ;;
-            *)
-              echo "::error::change_level must be major, minor, or patch (got: $CHANGE_LEVEL)"
-              exit 1
-              ;;
-          esac
+          change_level = os.environ["CHANGE_LEVEL"]
+          packages_raw = os.environ["PACKAGES"]
+          description = os.environ["DESCRIPTION"]
+          pr_number = os.environ["PR_NUMBER"]
 
-          if [[ -z "${PACKAGES//[[:space:]]/}" ]]; then
-            echo "::error::packages input must not be empty"
-            exit 1
-          fi
+          if change_level not in {"major", "minor", "patch"}:
+              print(
+                  f"::error::change_level must be major, minor, or patch (got: {change_level})",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
 
-          if [[ -z "${DESCRIPTION//[[:space:]]/}" ]]; then
-            echo "::error::description input must not be empty"
-            exit 1
-          fi
+          if not description.strip():
+              print("::error::description input must not be empty", file=sys.stderr)
+              sys.exit(1)
 
-          filename="pr-${PR_NUMBER}-$(openssl rand -hex 4)"
-          filepath=".changeset/${filename}.md"
+          config = json.loads(pathlib.Path(".changeset/config.json").read_text())
+          ignored = set(config.get("ignore") or [])
 
-          {
-            echo "---"
-            IFS=',' read -ra PACKAGE_LIST <<< "$PACKAGES"
-            for raw in "${PACKAGE_LIST[@]}"; do
-              pkg="$(echo "$raw" | xargs)"
-              if [[ -z "$pkg" ]]; then
-                continue
-              fi
+          package_manifests = [
+              *pathlib.Path(".").glob("packages/*/package.json"),
+              *pathlib.Path(".").glob("apps/*/package.json"),
+              *pathlib.Path(".").glob("examples/*/package.json"),
+          ]
+          scripts_manifest = pathlib.Path("scripts/package.json")
+          if scripts_manifest.exists():
+              package_manifests.append(scripts_manifest)
 
-              # Allow short names like "adapter" in addition to scoped names
-              if [[ "$pkg" != @*/* ]]; then
-                pkg="@astro-aws/${pkg#@astro-aws/}"
-              fi
+          managed = {
+              json.loads(path.read_text())["name"]
+              for path in package_manifests
+              if json.loads(path.read_text())["name"] not in ignored
+          }
 
-              printf '"%s": %s\n' "$pkg" "$CHANGE_LEVEL"
-            done
-            echo "---"
-            echo ""
-            printf '%s\n' "$DESCRIPTION"
-          } > "$filepath"
+          name_re = re.compile(r"^@[a-z0-9-]+/[a-z0-9-]+$")
+          resolved: list[str] = []
+          seen: set[str] = set()
 
-          if ! grep -q '^"' "$filepath"; then
-            echo "::error::No valid packages were provided"
-            exit 1
-          fi
+          for raw in packages_raw.split(","):
+              pkg = raw.strip()
+              if not pkg:
+                  continue
+              if "/" not in pkg:
+                  pkg = f"@astro-aws/{pkg.removeprefix('@astro-aws/')}"
+              if not name_re.fullmatch(pkg):
+                  print(f"::error::Invalid package name: {pkg}", file=sys.stderr)
+                  sys.exit(1)
+              if pkg not in managed:
+                  allowed = ", ".join(sorted(managed)) or "(none)"
+                  print(
+                      f"::error::{pkg} is not a managed package. Allowed: {allowed}",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+              if pkg not in seen:
+                  resolved.append(pkg)
+                  seen.add(pkg)
 
-          echo "Created $filepath:"
-          cat "$filepath"
+          if not resolved:
+              print("::error::packages input must not be empty", file=sys.stderr)
+              sys.exit(1)
 
-          echo "filepath=$filepath" >> "$GITHUB_OUTPUT"
-          echo "filename=$filename" >> "$GITHUB_OUTPUT"
+          filename = f"pr-{pr_number}-{os.urandom(4).hex()}"
+          filepath = pathlib.Path(".changeset") / f"{filename}.md"
+          frontmatter = "\n".join(f'"{pkg}": {change_level}' for pkg in resolved)
+          filepath.write_text(f"---\n{frontmatter}\n---\n\n{description.rstrip()}\n")
+
+          print(f"Created {filepath}:")
+          print(filepath.read_text())
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              print(f"filepath={filepath}", file=output)
+              print(f"filename={filename}", file=output)
+          PY
 
       - name: Commit and push changeset
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
           FILEPATH: ${{ steps.changeset.outputs.filepath }}
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |

--- a/.github/workflows/add-changeset.yml
+++ b/.github/workflows/add-changeset.yml
@@ -1,0 +1,123 @@
+name: Add Changeset
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to add the changeset to
+        required: true
+        type: string
+      packages:
+        description: Comma-separated package names (e.g. @astro-aws/adapter,@astro-aws/constructs)
+        required: true
+        type: string
+      change_level:
+        description: Semver bump level for the listed packages
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      description:
+        description: Changeset summary shown in the changelog
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  add-changeset:
+    name: Add changeset to PR
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Prefer a PAT so pushes work for maintainer workflows and fork PRs when configured
+          token: ${{ secrets.GH_PAT || github.token }}
+
+      - name: Checkout pull request branch
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: gh pr checkout "$PR_NUMBER"
+
+      - name: Create changeset
+        id: changeset
+        env:
+          PACKAGES: ${{ inputs.packages }}
+          CHANGE_LEVEL: ${{ inputs.change_level }}
+          DESCRIPTION: ${{ inputs.description }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          case "$CHANGE_LEVEL" in
+            major|minor|patch) ;;
+            *)
+              echo "::error::change_level must be major, minor, or patch (got: $CHANGE_LEVEL)"
+              exit 1
+              ;;
+          esac
+
+          if [[ -z "${PACKAGES//[[:space:]]/}" ]]; then
+            echo "::error::packages input must not be empty"
+            exit 1
+          fi
+
+          if [[ -z "${DESCRIPTION//[[:space:]]/}" ]]; then
+            echo "::error::description input must not be empty"
+            exit 1
+          fi
+
+          filename="pr-${PR_NUMBER}-$(openssl rand -hex 4)"
+          filepath=".changeset/${filename}.md"
+
+          {
+            echo "---"
+            IFS=',' read -ra PACKAGE_LIST <<< "$PACKAGES"
+            for raw in "${PACKAGE_LIST[@]}"; do
+              pkg="$(echo "$raw" | xargs)"
+              if [[ -z "$pkg" ]]; then
+                continue
+              fi
+
+              # Allow short names like "adapter" in addition to scoped names
+              if [[ "$pkg" != @*/* ]]; then
+                pkg="@astro-aws/${pkg#@astro-aws/}"
+              fi
+
+              printf '"%s": %s\n' "$pkg" "$CHANGE_LEVEL"
+            done
+            echo "---"
+            echo ""
+            printf '%s\n' "$DESCRIPTION"
+          } > "$filepath"
+
+          if ! grep -q '^"' "$filepath"; then
+            echo "::error::No valid packages were provided"
+            exit 1
+          fi
+
+          echo "Created $filepath:"
+          cat "$filepath"
+
+          echo "filepath=$filepath" >> "$GITHUB_OUTPUT"
+          echo "filename=$filename" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push changeset
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          FILEPATH: ${{ steps.changeset.outputs.filepath }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add "$FILEPATH"
+          git commit -m "Add changeset for PR #${PR_NUMBER}"
+          git push


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `workflow_dispatch` GitHub Actions workflow that maintainers can run to add a changeset file to an existing pull request.

### Inputs

| Input | Description |
| --- | --- |
| `pr_number` | Pull request to update |
| `packages` | Comma-separated package names (scoped like `@astro-aws/adapter` or short like `adapter`) |
| `change_level` | `patch`, `minor`, or `major` |
| `description` | Changeset summary used in the changelog |

### Behavior

1. Requires `GH_PAT` so the push retriggers `pull_request` checks
2. Checks out the target PR branch (`gh pr checkout`)
3. Writes a `.changeset/*.md` file after validating packages against managed (non-ignored) workspace names
4. Commits and pushes to the PR branch

Dispatches that target the same PR are serialized via a concurrency group so overlapping runs do not lose a changeset to a non-fast-forward push.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecd24d14-9723-4341-9e16-b2227e895c53?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecd24d14-9723-4341-9e16-b2227e895c53&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

